### PR TITLE
Use a function expression instead of declaration

### DIFF
--- a/src/Native/LocalStorage.js
+++ b/src/Native/LocalStorage.js
@@ -3,7 +3,7 @@ var _elm_lang$persistent_cache$Native_LocalStorage = function() {
 
 if (!localStorage || !localStorage.getItem || !localStorage.setItem)
 {
-	function disabled()
+	var disabled = function()
 	{
 		return _elm_lang$core$Native_Scheduler.fail({ ctor: 'Disabled' });
 	}


### PR DESCRIPTION
Received the following error in Safari on iOS 9.3
`Strict mode does not allow function declarations in a lexically nested statement.`

Changing the function to an expression fixed the issue.